### PR TITLE
Add journeyConfig (step 2/5)

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -33,6 +33,7 @@ module.exports.dbBuilder = {
       [dbJourneyId] = (await this.knexConnectionAsync.insert([{
         name: journey.name,
         descr: journey.descr,
+        journeyConfig: journey.journeyConfig,
         entityTypeName: journey.entityTypeName,
         journeyStatusId: (process.env.NODE_ENV === 'development') ? 3 : 2, // make live when in devel mode
       }], 'journeyId').into('core.journey'));

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -248,6 +248,7 @@ module.exports.handlers = {
     // possible todo: additional rule checking. ie, must belongn to campaigncontainer
     target.voltQuery = data.voltquery;
     target.entityTypeName = data.entitytypename;
+    target.journeyConfig = data.journeyconfig;
   },
   action: (data, target, csvHeaders) => {
     target.actionId = data.actionid;

--- a/service/schema/create.ddl
+++ b/service/schema/create.ddl
@@ -39,7 +39,8 @@ CREATE TABLE IF NOT EXISTS core."journey"(
   "descr" VARCHAR(128) NULL,
   "deleted" TIMESTAMP NULL,
   "voltQuery" TEXT NULL,
-  "GUIData" JSON
+  "GUIData" JSON,
+  "journeyConfig" JSONB
 );
 COMMENT ON TABLE core."journey" IS 'Defines journeys';
 


### PR DESCRIPTION
In order to allow flexible journey configuration, for things like control group size, we're adding a `journeyConfig` field to the track container on Lucidchart.

This PR is changing the importer so that it adds the config to the DB in Envoy if it is there.

Here is an example of Envoy being started with a journey that has `journeyConfig` and it is being pulled through.

![Screenshot 2019-09-20 at 17 04 36](https://user-images.githubusercontent.com/37520401/65341667-c4033f00-dbc8-11e9-81dc-a753e77c43af.png)

And here it is in the local DB (now with JSONB instead of JSON as requested).

<img width="1024" alt="Screenshot 2019-09-20 at 17 03 49" src="https://user-images.githubusercontent.com/37520401/65341614-a9c96100-dbc8-11e9-9da5-a93fd1e91851.png">