### PR TITLE
Adds empty string checking to journeyConfig

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -23,7 +23,12 @@ module.exports.dbBuilder = {
   },
 
   async haveJourney(journey) {
-    journey.journeyConfig = JSON.parse(journey.journeyConfig);
+    let { journeyConfig } = journey;
+    try {
+      journeyConfig = JSON.parse(journey.journeyConfig);
+    } catch (err) {
+      journeyConfig = null;
+    }
     if ((journey.journeyConfig.controlGroup && journey.journeyConfig.controlGroup > 1)
     || (journey.journeyConfig.controlGroup && journey.journeyConfig.controlGroup < 0)) {
       logger.error('Journey config control group is not between 0 and 1! Please make it a number representing a percentage, like 0.25 for 25%');
@@ -41,7 +46,7 @@ module.exports.dbBuilder = {
       [dbJourneyId] = (await this.knexConnectionAsync.insert([{
         name: journey.name,
         descr: journey.descr,
-        journeyConfig: journey.journeyConfig,
+        journeyConfig: journeyConfig,
         entityTypeName: journey.entityTypeName,
         journeyStatusId: (process.env.NODE_ENV === 'development') ? 3 : 2, // make live when in devel mode
       }], 'journeyId').into('core.journey'));

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -27,7 +27,7 @@ module.exports.dbBuilder = {
     try {
       journeyConfig = JSON.parse(journey.journeyConfig);
     } catch (err) {
-      journeyConfig = null;
+      journeyConfig = '{}';
     }
     if ((journey.journeyConfig.controlGroup && journey.journeyConfig.controlGroup > 1)
     || (journey.journeyConfig.controlGroup && journey.journeyConfig.controlGroup < 0)) {
@@ -46,7 +46,7 @@ module.exports.dbBuilder = {
       [dbJourneyId] = (await this.knexConnectionAsync.insert([{
         name: journey.name,
         descr: journey.descr,
-        journeyConfig: journeyConfig,
+        journeyConfig,
         entityTypeName: journey.entityTypeName,
         journeyStatusId: (process.env.NODE_ENV === 'development') ? 3 : 2, // make live when in devel mode
       }], 'journeyId').into('core.journey'));

--- a/service/schema/create.ddl
+++ b/service/schema/create.ddl
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS core."journey"(
   "deleted" TIMESTAMP NULL,
   "voltQuery" TEXT NULL,
   "GUIData" JSON,
-  "journeyConfig" JSONB
+  "journeyConfig" JSONB NULL
 );
 COMMENT ON TABLE core."journey" IS 'Defines journeys';
 

--- a/service/schema/create.ddl
+++ b/service/schema/create.ddl
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS core."journey"(
   "deleted" TIMESTAMP NULL,
   "voltQuery" TEXT NULL,
   "GUIData" JSON,
-  "journeyConfig" JSONB NULL
+  "journeyConfig" JSONB
 );
 COMMENT ON TABLE core."journey" IS 'Defines journeys';
 


### PR DESCRIPTION
We found a bug where it crashed Envoy if there was no journeyConfig. 

Now adds an empty object if there is no journeyConfig.